### PR TITLE
Login affiche "Nom de la salle" plutôt que "Mot de passe" et "Nom d'utilisateur" au lieu d' "Adresse courriel"

### DIFF
--- a/client/src/pages/Teacher/Login/Login.tsx
+++ b/client/src/pages/Teacher/Login/Login.tsx
@@ -49,7 +49,7 @@ const Login: React.FC = () => {
                 variant="outlined"
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
-                placeholder="Nom d'utilisateur"
+                placeholder="Adresse courriel"
                 sx={{ marginBottom: '1rem' }}
                 fullWidth
             />
@@ -60,7 +60,7 @@ const Login: React.FC = () => {
                 type="password"
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
-                placeholder="Nom de la salle"
+                placeholder="Mot de passe"
                 sx={{ marginBottom: '1rem' }}
                 fullWidth
             />


### PR DESCRIPTION
Fixes #179